### PR TITLE
Fix failure in nested groupBy with multiple aggregators with same fieldName

### DIFF
--- a/common/src/main/java/io/druid/collections/LoadBalancingPool.java
+++ b/common/src/main/java/io/druid/collections/LoadBalancingPool.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.collections;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.metamx.common.logger.Logger;
+
+import java.io.IOException;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Simple load balancing pool that always returns the least used item.
+ *
+ * An item's usage is incremented every time one gets requested from the pool
+ * and is decremented every time close is called on the holder.
+ *
+ * The pool eagerly instantiates all the items in the pool when created,
+ * using the given supplier.
+ *
+ * @param <T> type of items to pool
+ */
+public class LoadBalancingPool<T> implements Supplier<ResourceHolder<T>>
+{
+  private static final Logger log = new Logger(LoadBalancingPool.class);
+
+  private final Supplier<T> generator;
+  private final int capacity;
+  private final PriorityBlockingQueue<CountingHolder> queue;
+
+  public LoadBalancingPool(int capacity, Supplier<T> generator)
+  {
+    Preconditions.checkArgument(capacity > 0, "capacity must be greater than 0");
+    Preconditions.checkNotNull(generator);
+
+    this.generator = generator;
+    this.capacity = capacity;
+    this.queue = new PriorityBlockingQueue<>(capacity);
+
+    // eagerly intantiate all items in the pool
+    init();
+  }
+
+  private void init() {
+    for(int i = 0; i < capacity; ++i) {
+      queue.offer(new CountingHolder(generator.get()));
+    }
+  }
+
+  public ResourceHolder<T> get()
+  {
+    final CountingHolder holder;
+    // items never stay out of the queue for long, so we'll get one eventually
+    try {
+      holder = queue.take();
+    } catch(InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw Throwables.propagate(e);
+    }
+
+    // synchronize on item to ensure count cannot get changed by
+    // CountingHolder.close right after we put the item back in the queue
+    synchronized (holder) {
+      holder.count.incrementAndGet();
+      queue.offer(holder);
+    }
+    return holder;
+  }
+
+  private class CountingHolder implements ResourceHolder<T>, Comparable<CountingHolder>
+  {
+    private AtomicInteger count = new AtomicInteger(0);
+    private final T object;
+
+    public CountingHolder(final T object)
+    {
+      this.object = object;
+    }
+
+    @Override
+    public T get()
+    {
+      return object;
+    }
+
+    /**
+     * Not idempotent, should only be called once when done using the resource
+     *
+     * @throws IOException
+     */
+    @Override
+    public void close() throws IOException
+    {
+      // ensures count always gets adjusted while item is removed from the queue
+      synchronized (this) {
+        // item may not be in queue if another thread is calling LoadBalancingPool.get()
+        // at the same time; in that case let the other thread put it back.
+        boolean removed = queue.remove(this);
+        count.decrementAndGet();
+        if (removed) {
+          queue.offer(this);
+        }
+      }
+    }
+
+    @Override
+    public int compareTo(CountingHolder o)
+    {
+      return Integer.compare(count.get(), o.count.get());
+    }
+
+
+    @Override
+    protected void finalize() throws Throwable
+    {
+      try {
+        final int shouldBeZero = count.get();
+        if (shouldBeZero != 0) {
+          log.warn("Expected 0 resource count, got [%d]! Object was[%s].", shouldBeZero, object);
+        }
+      }
+      finally {
+        super.finalize();
+      }
+    }
+  }
+}

--- a/common/src/main/java/io/druid/collections/ResourceHolder.java
+++ b/common/src/main/java/io/druid/collections/ResourceHolder.java
@@ -23,5 +23,5 @@ import java.io.Closeable;
  */
 public interface ResourceHolder<T> extends Closeable
 {
-  public T get();
+  T get();
 }

--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -109,3 +109,4 @@ You can optionally only configure caching to be enabled on the broker by setting
 |`druid.cache.hosts`|Command separated list of Memcached hosts `<host:port>`.|none|
 |`druid.cache.maxObjectSize`|Maximum object size in bytes for a Memcached object.|52428800 (50 MB)|
 |`druid.cache.memcachedPrefix`|Key prefix for all keys in Memcached.|druid|
+|`druid.cache.numConnections`|Number of memcached connections to use.|1|

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -110,3 +110,41 @@ The following matches dimension values in `[product_1, product_3, product_5]` fo
     }
 }
 ```
+### Search filter
+
+Search filters can be used to filter on partial string matches. 
+
+```json
+{
+    "filter": {
+        "type": "search",
+        "dimension": "product",
+        "query": {
+          "type": "insensitive_contains",
+          "value": "foo" 
+        }        
+    }
+}
+```
+
+|property|description|required?|
+|--------|-----------|---------|
+|type|This String should always be "search".|yes|
+|dimension|The dimension to perform the search over.|yes|
+|query|A JSON object for the type of search. See below for more information.|yes|
+
+#### Search Query Spec
+
+##### Insensitive Contains
+
+|property|description|required?|
+|--------|-----------|---------|
+|type|This String should always be "insensitive_contains".|yes|
+|value|A String value to run the search over.|yes|
+
+##### Fragment
+
+|property|description|required?|
+|--------|-----------|---------|
+|type|This String should always be "fragment".|yes|
+|values|A JSON array of String values to run the search over. Case insensitive.|yes|

--- a/examples/bin/run_example_server.sh
+++ b/examples/bin/run_example_server.sh
@@ -39,6 +39,7 @@ JAVA_ARGS="-Xmx512m -Duser.timezone=UTC -Dfile.encoding=UTF-8"
 JAVA_ARGS="${JAVA_ARGS} -Ddruid.realtime.specFile=${SPEC_FILE}"
 JAVA_ARGS="${JAVA_ARGS} -Ddruid.extensions.localRepository=${MAVEN_DIR}"
 JAVA_ARGS="${JAVA_ARGS} -Ddruid.extensions.remoteRepositories=[]"
+JAVA_ARGS="${JAVA_ARGS} -Ddruid.publish.type=noop"
 
 DRUID_CP=${EXAMPLE_LOC}
 #For a pull

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -237,7 +237,12 @@ public class IngestSegmentFirehoseFactoryTimelineTest
             "2000/2000T02", 3, 7,
             DS("2000/2000T02", "v1", 0, IR("2000", 1), IR("2000T00:01", 2), IR("2000T01", 8)),
             DS("2000T01/2000T02", "v2", 0, IR("2000T01:01", 4))
-        ) /* 1H segment overlayed on top of 2H segment */,
+        ) /* 1H segment overlaid on top of 2H segment */,
+        TC(
+            "2000/2000-01-02", 4, 23,
+            DS("2000/2000-01-02", "v1", 0, IR("2000", 1), IR("2000T00:01", 2), IR("2000T01", 8), IR("2000T02", 16)),
+            DS("2000T01/2000T02", "v2", 0, IR("2000T01:01", 4))
+        ) /* 1H segment overlaid on top of 1D segment */,
         TC(
             "2000/2000T02", 4, 15,
             DS("2000/2000T02", "v1", 0, IR("2000", 1), IR("2000T00:01", 2), IR("2000T01", 8)),

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -159,8 +159,18 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
 
       final Sequence<Row> subqueryResult = mergeGroupByResults(subquery, runner, context);
       final List<AggregatorFactory> aggs = Lists.newArrayList();
+
       for (AggregatorFactory aggregatorFactory : query.getAggregatorSpecs()) {
-        aggs.addAll(aggregatorFactory.getRequiredColumns());
+        for (final AggregatorFactory column : aggregatorFactory.getRequiredColumns()) {
+          if (!Iterables.any(aggs, new Predicate<AggregatorFactory>() {
+            @Override
+            public boolean apply(AggregatorFactory existingAgg) {
+              return existingAgg.getName().equals(column.getName());
+            }
+          })) {
+            aggs.add(column);
+          }
+        }
       }
 
       // We need the inner incremental index to have all the columns required by the outer query

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -114,10 +114,6 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
               return arg1;
             }
 
-            if (!query.isMerge()) {
-              throw new ISE("Merging when a merge isn't supposed to happen[%s], [%s]", arg1, arg2);
-            }
-
             List<Interval> newIntervals = JodaUtils.condenseIntervals(
                 Iterables.concat(arg1.getIntervals(), arg2.getIntervals())
             );

--- a/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexStorageAdapter.java
@@ -105,6 +105,12 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
   }
 
   @Override
+  public int getNumRows()
+  {
+    return index.getNumRows();
+  }
+
+  @Override
   public DateTime getMinTime()
   {
     GenericColumn column = null;
@@ -134,6 +140,12 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
   public Capabilities getCapabilities()
   {
     return Capabilities.builder().dimensionValuesSorted(true).build();
+  }
+
+  @Override
+  public ColumnCapabilities getColumnCapabilities(String column)
+  {
+    return index.getColumn(column).getCapabilities();
   }
 
   @Override
@@ -275,7 +287,10 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                     }
 
                     @Override
-                    public DimensionSelector makeDimensionSelector(final String dimension, @Nullable final ExtractionFn extractionFn)
+                    public DimensionSelector makeDimensionSelector(
+                        final String dimension,
+                        @Nullable final ExtractionFn extractionFn
+                    )
                     {
                       final Column columnDesc = index.getColumn(dimension);
                       if (columnDesc == null) {
@@ -296,8 +311,7 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
 
                       if (column == null) {
                         return NULL_DIMENSION_SELECTOR;
-                      }
-                      else if (columnDesc.getCapabilities().hasMultipleValues()) {
+                      } else if (columnDesc.getCapabilities().hasMultipleValues()) {
                         return new DimensionSelector()
                         {
                           @Override
@@ -325,7 +339,9 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                           public int lookupId(String name)
                           {
                             if (extractionFn != null) {
-                              throw new UnsupportedOperationException("cannot perform lookup when applying an extraction function");
+                              throw new UnsupportedOperationException(
+                                  "cannot perform lookup when applying an extraction function"
+                              );
                             }
                             return column.lookupId(name);
                           }
@@ -388,7 +404,9 @@ public class QueryableIndexStorageAdapter implements StorageAdapter
                           public int lookupId(String name)
                           {
                             if (extractionFn != null) {
-                              throw new UnsupportedOperationException("cannot perform lookup when applying an extraction function");
+                              throw new UnsupportedOperationException(
+                                  "cannot perform lookup when applying an extraction function"
+                              );
                             }
                             return column.lookupId(name);
                           }

--- a/processing/src/main/java/io/druid/segment/StorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/StorageAdapter.java
@@ -17,6 +17,7 @@
 
 package io.druid.segment;
 
+import io.druid.segment.column.ColumnCapabilities;
 import io.druid.segment.data.Indexed;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -42,5 +43,7 @@ public interface StorageAdapter extends CursorFactory
   public DateTime getMinTime();
   public DateTime getMaxTime();
   public Capabilities getCapabilities();
+  public ColumnCapabilities getColumnCapabilities(String column);
+  public int getNumRows();
   public DateTime getMaxIngestedEventTime();
 }

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -20,11 +20,14 @@ package io.druid.segment.data;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.metamx.common.guava.Accumulator;
+import com.metamx.common.guava.Sequence;
 import com.metamx.common.guava.Sequences;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
@@ -74,7 +77,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -217,7 +219,7 @@ public class IncrementalIndexTest
     Assert.assertEquals(Arrays.asList("4"), row.getDimension("dim2"));
   }
 
-  @Test(timeout = 60000)
+  @Test(timeout = 60_000L)
   public void testConcurrentAddRead() throws InterruptedException, ExecutionException
   {
     final int dimensionCount = 5;
@@ -257,9 +259,8 @@ public class IncrementalIndexTest
 
 
     final IncrementalIndex index = indexCreator.createIndex(ingestAggregatorFactories.toArray(new AggregatorFactory[dimensionCount]));
-    final int taskCount = 30;
-    final int concurrentThreads = 3;
-    final int elementsPerThread = 100;
+    final int concurrentThreads = 2;
+    final int elementsPerThread = 10_000;
     final ListeningExecutorService indexExecutor = MoreExecutors.listeningDecorator(
         Executors.newFixedThreadPool(
             concurrentThreads,
@@ -281,8 +282,8 @@ public class IncrementalIndexTest
     );
     final long timestamp = System.currentTimeMillis();
     final Interval queryInterval = new Interval("1900-01-01T00:00:00Z/2900-01-01T00:00:00Z");
-    final List<ListenableFuture<?>> indexFutures = new LinkedList<>();
-    final List<ListenableFuture<?>> queryFutures = new LinkedList<>();
+    final List<ListenableFuture<?>> indexFutures = Lists.newArrayListWithExpectedSize(concurrentThreads);
+    final List<ListenableFuture<?>> queryFutures = Lists.newArrayListWithExpectedSize(concurrentThreads);
     final Segment incrementalIndexSegment = new IncrementalIndexSegment(index, null);
     final QueryRunnerFactory factory = new TimeseriesQueryRunnerFactory(
         new TimeseriesQueryQueryToolChest(QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()),
@@ -290,100 +291,115 @@ public class IncrementalIndexTest
         QueryRunnerTestHelper.NOOP_QUERYWATCHER
     );
     final AtomicInteger currentlyRunning = new AtomicInteger(0);
-    final AtomicBoolean concurrentlyRan = new AtomicBoolean(false);
+    final AtomicInteger concurrentlyRan = new AtomicInteger(0);
     final AtomicInteger someoneRan = new AtomicInteger(0);
     final CountDownLatch startLatch = new CountDownLatch(1);
-    try {
-      for (int j = 0; j < taskCount; j++) {
-        indexFutures.add(
-            indexExecutor.submit(
-                new Runnable()
+    final CountDownLatch readyLatch = new CountDownLatch(concurrentThreads * 2);
+    final AtomicInteger queriesAccumualted = new AtomicInteger(0);
+    for (int j = 0; j < concurrentThreads; j++) {
+      indexFutures.add(
+          indexExecutor.submit(
+              new Runnable()
+              {
+                @Override
+                public void run()
                 {
-                  @Override
-                  public void run()
-                  {
-                    try {
-                      startLatch.await();
-                    }
-                    catch (InterruptedException e) {
-                      Thread.currentThread().interrupt();
-                      throw Throwables.propagate(e);
-                    }
-                    currentlyRunning.incrementAndGet();
-                    try {
-                      for (int i = 0; i < elementsPerThread; i++) {
-                        someoneRan.incrementAndGet();
-                        index.add(getLongRow(timestamp + i, i, dimensionCount));
-                      }
-                    }
-                    catch (IndexSizeExceededException e) {
-                      throw Throwables.propagate(e);
-                    }
-                    currentlyRunning.decrementAndGet();
+                  readyLatch.countDown();
+                  try {
+                    startLatch.await();
                   }
+                  catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw Throwables.propagate(e);
+                  }
+                  currentlyRunning.incrementAndGet();
+                  try {
+                    for (int i = 0; i < elementsPerThread; i++) {
+                      index.add(getLongRow(timestamp + i, i, dimensionCount));
+                      someoneRan.incrementAndGet();
+                    }
+                  }
+                  catch (IndexSizeExceededException e) {
+                    throw Throwables.propagate(e);
+                  }
+                  currentlyRunning.decrementAndGet();
                 }
-            )
-        );
+              }
+          )
+      );
 
-        final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
-                                      .dataSource("xxx")
-                                      .granularity(QueryGranularity.ALL)
-                                      .intervals(ImmutableList.of(queryInterval))
-                                      .aggregators(queryAggregatorFactories)
-                                      .build();
-        queryFutures.add(
-            queryExecutor.submit(
-                new Runnable()
+      final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
+                                          .dataSource("xxx")
+                                          .granularity(QueryGranularity.ALL)
+                                          .intervals(ImmutableList.of(queryInterval))
+                                          .aggregators(queryAggregatorFactories)
+                                          .build();
+      queryFutures.add(
+          queryExecutor.submit(
+              new Runnable()
+              {
+                @Override
+                public void run()
                 {
-                  @Override
-                  public void run()
-                  {
-                    try {
-                      startLatch.await();
-                    }
-                    catch (InterruptedException e) {
-                      Thread.currentThread().interrupt();
-                      throw Throwables.propagate(e);
-                    }
+                  readyLatch.countDown();
+                  try {
+                    startLatch.await();
+                  }
+                  catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw Throwables.propagate(e);
+                  }
+                  while (concurrentlyRan.get() == 0) {
                     QueryRunner<Result<TimeseriesResultValue>> runner = new FinalizeResultsQueryRunner<Result<TimeseriesResultValue>>(
                         factory.createRunner(incrementalIndexSegment),
                         factory.getToolchest()
                     );
                     Map<String, Object> context = new HashMap<String, Object>();
-                    for (Result<TimeseriesResultValue> result :
-                        Sequences.toList(
-                            runner.run(query, context),
-                            new LinkedList<Result<TimeseriesResultValue>>()
+                    Sequence<Result<TimeseriesResultValue>> sequence = runner.run(query, context);
+
+                    for (Double result :
+                        sequence.accumulate(
+                            new Double[0], new Accumulator<Double[], Result<TimeseriesResultValue>>()
+                            {
+                              @Override
+                              public Double[] accumulate(
+                                  Double[] accumulated, Result<TimeseriesResultValue> in
+                              )
+                              {
+                                if (currentlyRunning.get() > 0) {
+                                  concurrentlyRan.incrementAndGet();
+                                }
+                                queriesAccumualted.incrementAndGet();
+                                return Lists.asList(in.getValue().getDoubleMetric("doubleSumResult0"), accumulated)
+                                            .toArray(new Double[accumulated.length + 1]);
+                              }
+                            }
                         )
                         ) {
                       final Integer ranCount = someoneRan.get();
                       if (ranCount > 0) {
-                        final Double sumResult = result.getValue().getDoubleMetric("doubleSumResult0");
                         // Eventually consistent, but should be somewhere in that range
                         // Actual result is validated after all writes are guaranteed done.
                         Assert.assertTrue(
-                            String.format("%d >= %g >= 0 violated", ranCount, sumResult),
-                            sumResult >= 0 && sumResult <= ranCount
+                            String.format("%d >= %g >= 0 violated", ranCount, result),
+                            result >= 0 && result <= ranCount
                         );
-                      }
-                      if (currentlyRunning.get() > 0) {
-                        concurrentlyRan.set(true);
                       }
                     }
                   }
                 }
-            )
-        );
-      }
+              }
+          )
+      );
     }
-    finally {
-      startLatch.countDown();
-    }
+    readyLatch.await();
+    startLatch.countDown();
     List<ListenableFuture<?>> allFutures = new ArrayList<>(queryFutures.size() + indexFutures.size());
     allFutures.addAll(queryFutures);
     allFutures.addAll(indexFutures);
     Futures.allAsList(allFutures).get();
-    Assert.assertTrue("Did not hit concurrency, please try again", concurrentlyRan.get());
+    Assert.assertTrue("Queries ran too fast", queriesAccumualted.get() > 0);
+    Assert.assertTrue("Did not hit concurrency, please try again", concurrentlyRan.get() > 0);
     queryExecutor.shutdown();
     indexExecutor.shutdown();
     QueryRunner<Result<TimeseriesResultValue>> runner = new FinalizeResultsQueryRunner<Result<TimeseriesResultValue>>(
@@ -406,12 +422,12 @@ public class IncrementalIndexTest
       for (int i = 0; i < dimensionCount; ++i) {
         Assert.assertEquals(
             String.format("Failed long sum on dimension %d", i),
-            elementsPerThread * taskCount,
+            elementsPerThread * concurrentThreads,
             result.getValue().getLongMetric(String.format("sumResult%s", i)).intValue()
         );
         Assert.assertEquals(
             String.format("Failed double sum on dimension %d", i),
-            elementsPerThread * taskCount,
+            elementsPerThread * concurrentThreads,
             result.getValue().getDoubleMetric(String.format("doubleSumResult%s", i)).intValue()
         );
       }

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -376,13 +376,13 @@ public class IncrementalIndexTest
                             }
                         )
                         ) {
-                      final Integer ranCount = someoneRan.get();
-                      if (ranCount > 0) {
+                      final Integer maxValueExpected = someoneRan.get() + concurrentThreads;
+                      if (maxValueExpected > 0) {
                         // Eventually consistent, but should be somewhere in that range
                         // Actual result is validated after all writes are guaranteed done.
                         Assert.assertTrue(
-                            String.format("%d >= %g >= 0 violated", ranCount, result),
-                            result >= 0 && result <= ranCount
+                            String.format("%d >= %g >= 0 violated", maxValueExpected, result),
+                            result >= 0 && result <= maxValueExpected
                         );
                       }
                     }

--- a/server/src/main/java/io/druid/client/cache/MemcachedCacheConfig.java
+++ b/server/src/main/java/io/druid/client/cache/MemcachedCacheConfig.java
@@ -51,6 +51,10 @@ public class MemcachedCacheConfig
   @JsonProperty
   private long maxOperationQueueSize = 0;
 
+  // size of memcached connection pool
+  @JsonProperty
+  private int numConnections = 1;
+
   public int getExpiration()
   {
     return expiration;
@@ -84,5 +88,10 @@ public class MemcachedCacheConfig
   public int getReadBufferSize()
   {
     return readBufferSize;
+  }
+
+  public int getNumConnections()
+  {
+    return numConnections;
   }
 }

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -744,6 +744,14 @@ public class RealtimePlumber implements Plumber
               )
           );
         }
+        if (hydrants.isEmpty()) {
+          // Probably encountered a corrupt sink directory
+          log.warn(
+              "Found persisted segment directory with no intermediate segments present at %s, skipping sink creation.",
+              sinkDir.getAbsolutePath()
+          );
+          continue;
+        }
         Sink currSink = new Sink(sinkInterval, schema, config, versioningPolicy.getVersion(sinkInterval), hydrants);
         sinks.put(sinkInterval.getStartMillis(), currSink);
         sinkTimeline.add(

--- a/server/src/test/java/io/druid/client/cache/MemcachedCacheBenchmark.java
+++ b/server/src/test/java/io/druid/client/cache/MemcachedCacheBenchmark.java
@@ -20,7 +20,10 @@ package io.druid.client.cache;
 import com.google.caliper.Param;
 import com.google.caliper.Runner;
 import com.google.caliper.SimpleBenchmark;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
+import io.druid.collections.ResourceHolder;
+import io.druid.collections.StupidResourceHolder;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.DefaultHashAlgorithm;
@@ -77,7 +80,9 @@ public class MemcachedCacheBenchmark extends SimpleBenchmark
 
 
     cache = new MemcachedCache(
-        client,
+        Suppliers.<ResourceHolder<MemcachedClientIF>>ofInstance(
+            StupidResourceHolder.create(client)
+        ),
         new MemcachedCacheConfig()
         {
           @Override

--- a/server/src/test/java/io/druid/client/cache/MemcachedCacheTest.java
+++ b/server/src/test/java/io/druid/client/cache/MemcachedCacheTest.java
@@ -18,6 +18,7 @@
 package io.druid.client.cache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -34,6 +35,8 @@ import com.metamx.emitter.core.Event;
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.metrics.Monitor;
 import com.metamx.metrics.MonitorScheduler;
+import io.druid.collections.ResourceHolder;
+import io.druid.collections.StupidResourceHolder;
 import io.druid.guice.GuiceInjectors;
 import io.druid.guice.ManageLifecycle;
 import io.druid.initialization.Initialization;
@@ -110,8 +113,12 @@ public class MemcachedCacheTest
   @Before
   public void setUp() throws Exception
   {
-    MemcachedClientIF client = new MockMemcachedClient();
-    cache = new MemcachedCache(client, memcachedCacheConfig);
+    cache = new MemcachedCache(
+        Suppliers.<ResourceHolder<MemcachedClientIF>>ofInstance(
+            StupidResourceHolder.<MemcachedClientIF>create(new MockMemcachedClient())
+        ),
+        memcachedCacheConfig
+    );
   }
 
   @Test


### PR DESCRIPTION
Seems to be a side effect of using an intermediate IncrementalIndex to handle nested group bys. Fix is to prevent adding multiple columns with the same fieldName to the index. The AggregatorFactory type may be lost since it doesn't add subsequent factories with the same name, but I don't think that affects the function of the intermediate index.

This is a hack in the sense that the real solution is to re-write group-bys to not require massaging the data to work with IncrementalIndex.

Closes #1419